### PR TITLE
[2/3] Settings: Add ProximityWake

### DIFF
--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -120,6 +120,12 @@
                 android:summary="%s"
                 android:title="@string/display_vr_pref_title" />
 
+        <slim.preference.SlimSwitchPreference
+                android:key="proximity_on_wake"
+                android:title="@*slim:string/proximity_wake_title"
+                android:summary="@*slim:string/proximity_wake_summary"
+                android:defaultValue="false" />
+
         <PreferenceCategory
             android:key="category_doze_options"
             android:title="@*slim:string/display_category_doze_options_title" >

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -102,6 +102,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private static final int SHOW_NETWORK_NAME_ON = 1;
     private static final int SHOW_NETWORK_NAME_OFF = 0;
     private static final String PREF_KEY_DOUBLE_TAP_POWER = "gesture_double_tap_power"; //temp
+    private static final String KEY_PROXIMITY_WAKE = "proximity_on_wake";
 
     private Preference mFontSizePref;
 
@@ -117,6 +118,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
     private SwitchPreference mCameraGesturePreference;
     private SwitchPreference mCameraDoubleTapPowerGesturePreference;
     private SwitchPreference mNetworkNameDisplayedPreference = null;
+    private SwitchPreference mProximityCheckOnWakePreference;
 
     @Override
     protected int getMetricsCategory() {
@@ -286,6 +288,17 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
             mNightModePreference.setValue(String.valueOf(currentNightMode));
             mNightModePreference.setOnPreferenceChangeListener(this);
         }
+
+        mProximityCheckOnWakePreference = (SwitchPreference) findPreference(KEY_PROXIMITY_WAKE);
+        boolean proximityCheckOnWake = getResources().getBoolean(
+                com.android.internal.R.bool.config_proximityCheckOnWake);
+        if (!proximityCheckOnWake) {
+            if (mProximityCheckOnWakePreference != null) {
+                removePreference(KEY_PROXIMITY_WAKE);
+            }
+            SlimSettings.System.putInt(resolver, SlimSettings.System.PROXIMITY_ON_WAKE, 0);
+        }
+
     }
 
     private static boolean allowAllRotations(Context context) {


### PR DESCRIPTION
Yank555.lu : if device does not support it (not enabled in overlay), disable it

Settings: Add proximity wake option

Ports and combines:

http://review.cyanogenmod.org/#/c/66658/
Settings : Add preference for proximity wake

http://review.cyanogenmod.org/#/c/69347/
Proximity Wake-Up : adjust strings

http://review.cyanogenmod.org/#/c/69803/
Settings : Make proximity opt-in

Change-Id: Iea0853eccf764438c7aaac76afd13c364fcea0ec
Signed-off-by: Danesh M <daneshm90@gmail.com>
Signed-off-by: Daniel Koman <dankoman30@gmail.com>
Signed-off-by: Jean-Pierre Rasquin <yank555.lu@gmail.com>