### PR TITLE
MSIM: Fix user set DDS sub in hotswap cases.

### DIFF
--- a/src/com/android/settings/sim/SimDialogActivity.java
+++ b/src/com/android/settings/sim/SimDialogActivity.java
@@ -29,6 +29,7 @@ import android.telecom.TelecomManager;
 import android.telephony.SubscriptionInfo;
 import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -55,6 +56,8 @@ public class SimDialogActivity extends Activity {
     public static final int CALLS_PICK = 1;
     public static final int SMS_PICK = 2;
     public static final int PREFERRED_PICK = 3;
+
+    private static final String SETTING_USER_PREF_DATA_SUB = "user_preferred_data_sub";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -97,6 +100,7 @@ public class SimDialogActivity extends Activity {
                     PhoneAccountHandle phoneAccountHandle =
                             subscriptionIdToPhoneAccountHandle(subId);
                     setDefaultDataSubId(context, subId);
+                    setUserPrefDataSubIdInDb(subId);
                     setDefaultSmsSubId(context, subId);
                     setUserSelectedOutgoingPhoneAccount(phoneAccountHandle);
                     finish();
@@ -120,6 +124,12 @@ public class SimDialogActivity extends Activity {
         final SubscriptionManager subscriptionManager = SubscriptionManager.from(context);
         subscriptionManager.setDefaultDataSubId(subId);
         Toast.makeText(context, R.string.data_switch_started, Toast.LENGTH_LONG).show();
+    }
+
+    private void setUserPrefDataSubIdInDb(int subId) {
+        android.provider.Settings.Global.putInt(getContentResolver(),
+                SETTING_USER_PREF_DATA_SUB, subId);
+        Log.d(TAG, "updating data subId: " + subId + " in DB");
     }
 
     private static void setDefaultSmsSubId(final Context context, final int subId) {
@@ -167,6 +177,7 @@ public class SimDialogActivity extends Activity {
                             case DATA_PICK:
                                 sir = subInfoList.get(value);
                                 setDefaultDataSubId(context, sir.getSubscriptionId());
+                                setUserPrefDataSubIdInDb(sir.getSubscriptionId());
                                 break;
                             case CALLS_PICK:
                                 final TelecomManager telecomManager =


### PR DESCRIPTION
Currently if user set DDS sim is removed and inserted,
dds will not fallback to user preferred sub.

Fix: Save the user preferred DDS sub in DB and set it
as DDS sub, when sim is removed and inserted.

Change-Id: Ic34fdbad70a7dc99a0fa5de9cbb9d24caa6bac87
CRs-Fixed: 958445